### PR TITLE
Fix matrix multiplication in FilterRLS (#3).

### DIFF
--- a/padasip/filters/rls.py
+++ b/padasip/filters/rls.py
@@ -217,7 +217,8 @@ class FilterRLS(AdaptiveFilter):
         """
         y = np.dot(self.w, x)
         e = d - y
-        R1 = np.dot(np.dot(np.dot(self.R,x),x.T),self.R)
+        x_2d = x[:, np.newaxis]
+        R1 = np.dot(np.dot(np.dot(self.R,x_2d),x_2d.T),self.R)
         R2 = self.mu + np.dot(np.dot(x,self.R),x.T)
         self.R = 1/self.mu * (self.R - R1/R2)
         dw = np.dot(self.R, x.T) * e
@@ -265,7 +266,8 @@ class FilterRLS(AdaptiveFilter):
             self.w_history[k,:] = self.w
             y[k] = np.dot(self.w, x[k])
             e[k] = d[k] - y[k]
-            R1 = np.dot(np.dot(np.dot(self.R,x[k]),x[k].T),self.R)
+            xk_2d = x[k][:, np.newaxis]
+            R1 = np.dot(np.dot(np.dot(self.R,xk_2d),xk_2d.T),self.R)
             R2 = self.mu + np.dot(np.dot(x[k],self.R),x[k].T)
             self.R = 1/self.mu * (self.R - R1/R2)
             dw = np.dot(self.R, x[k].T) * e[k]

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -72,7 +72,12 @@ class TestFilters(unittest.TestCase):
         d = 2*x[:,0] + 0.1*x[:,1] - 4*x[:,2] + 0.5*x[:,3] + v
         f = pa.filters.FilterRLS(n=4, mu=0.9, w="random")
         y, e, w = f.run(d, x)        
-        self.assertAlmostEqual(y.sum(), 12.466854176928789)
+        self.assertAlmostEqual(y.sum(), 15.463186820823049)
+        self.assertNotEqual(0, f.R[0, 1])
+
+        f = pa.filters.FilterRLS(n=4, mu=0.9, w="random")
+        f.adapt(d[0], x[0])
+        self.assertNotEqual(0, f.R[0, 1])
 
     def test_filter_LMF(self):
         """

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -13,7 +13,7 @@ class TestPreprocess(unittest.TestCase):
         """
         u = range(1000)
         x = pa.preprocess.standardize(u)
-        self.assertEqual(x.std(), 1.0)
+        self.assertAlmostEqual(x.std(), 1.0, 15)
         self.assertEqual(np.round(x.mean(), 3), -0.0)
         
     def test_standardize_back(self):


### PR DESCRIPTION
Fix an issue related to matrix multiplication in FilterRLS.  Specifically, since x is a 1d array, which has shape (n,), x.T is not really the transpose, and x.T has shape (n,) as well.  The fix is to create a 2d array which is equivalent to x with shape (n,1), so that the x.T is really the transpose and has shape (1,n).